### PR TITLE
11012018 recom engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Requirements
 =======================
 WordPress: at least **4.6**
 
-Tested up to: WordPress **4.9.2**
+Tested up to: WordPress **4.9.4**
 
 WooCommerce: at least **3.0.0**
 
-Tested up to: WooCommerce **3.2.6**
+Tested up to: WooCommerce **3.3.1**
 
 
 Install

--- a/README.md
+++ b/README.md
@@ -1,16 +1,41 @@
-# WooCommerce Retargeting #
-Author: Retargeting Team
-Tags: retargeting, WooCommerce
-Requires at least: 4.6
-Tested up to: 4.9.1
-Requires WooCommerce at least: 3.0.0
-Tested WooCommerce up to: 3.2.6
+![Retargeting.Biz Logo](https://s3.amazonaws.com/techpluto/wp-content/uploads/2017/06/29185746/techp_1194697.png)
 
-Retargeting is a marketing automation tool that boosts the conversion rate and sales of your online store.
+Retargeting Tracker for WooCommerce
+=======================
+Retargeting Tracker extension installs the required tagging for [Retargeting.Biz](https://Retargeting.biz)'s features in WooCommerce based online shops, providing your eCommerce business with all the necessary tools to build a strong conversion rate optimization strategy.
 
-# Installation #
+In order to implement the Retargeting Tracker extension you need to setup a [Retargeting.Biz](https://Retargeting.biz) account.
 
-1. Upload the entire 'woocommerce-retargeting' folder to the '/wp-content/plugins/' directory
-2. Activate the plugin through the 'Plugins' menu in WordPress
+Requirements
+=======================
+WordPress: at least **4.6**
 
-If you are NOT using WooCommerce 3.0+ please e-mail us at (mailto:info@retargeting.biz) and we will help you set up the installation.
+Tested up to: WordPress **4.9.2**
+
+WooCommerce: at least **3.0.0**
+
+Tested up to: WooCommerce **3.2.6**
+
+
+Install
+=======================
+##### 1. via WordPress Plugin Installation System
+- Log into your website's Administrator account
+- Go to `Plugins -> Add New` and search for `WooCommerce Retargeting` and click `Install`
+- Go to `WooCommerce -> Settings -> Integration` and click on the `Retargeting Tracker` tab
+- Insert your unique `Tracking API Key` and `REST API Key` (can be found inside your Retargeting.Biz account settings)
+- Click the `Save changes` button on the bottom of the page
+
+##### 2. via File Transfer Protocol (FTP)
+- Download [Retargeting Tracker](https://github.com/retargeting/WooCommerce/archive/master.zip)
+- Unarchive `WooCommerce-master.zip`
+- Copy and paste the `woocommerce-retargeting` folder into your `WordPressFolder/wp-content/plugins/`
+- Log into your website's Administrator account
+- Go to `Plugins -> Add New` and search for `WooCommerce Retargeting` and click `Install`
+- Go to `WooCommerce -> Settings -> Integration` and click on the `Retargeting Tracker` tab
+- Insert your unique `Tracking API Key` and `REST API Key` (can be found inside your Retargeting.Biz account settings)
+- Click the `Save changes` button on the bottom of the page
+
+Troubleshoot
+=======================
+Please contact us at info@retargeting.biz

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -29,15 +29,15 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         $this->init_form_fields();
         $this->init_settings();
 
-        $this->domain_api_key                  = $this->get_option('domain_api_key');
-        $this->token                           = $this->get_option('token');
-        $this->add_to_cart_button_id           = $this->get_option('add_to_cart_button_id');
-        $this->price_label_id                  = $this->get_option('price_label_id');
+        $this->domain_api_key                  = esc_attr( $this->get_option('domain_api_key') );
+        $this->token                           = esc_attr( $this->get_option('token') );
+        $this->add_to_cart_button_id           = esc_attr( $this->get_option('add_to_cart_button_id') );
+        $this->price_label_id                  = esc_attr( $this->get_option('price_label_id') );
         $this->help_pages                      = $this->get_option('help_pages');
-        $this->recom_engine_home_category_page = $this->get_option('recom_engine_home_category_page');
-        $this->recom_engine_product_page       = $this->get_option('recom_engine_product_page');
-        $this->recom_engine_checkout_form      = $this->get_option('recom_engine_checkout_form');
-        $this->recom_engine_thank_you_page     = $this->get_option('recom_engine_thank_you_page');
+        $this->recom_engine_home_category_page = esc_attr( $this->get_option('recom_engine_home_category_page') );
+        $this->recom_engine_product_page       = esc_attr( $this->get_option('recom_engine_product_page') );
+        $this->recom_engine_checkout_form      = esc_attr( $this->get_option('recom_engine_checkout_form') );
+        $this->recom_engine_thank_you_page     = esc_attr( $this->get_option('recom_engine_thank_you_page') );
         
         add_action('init', array($this, 'ra_session_init'), 1);
 

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -34,8 +34,10 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         $this->add_to_cart_button_id           = esc_attr( $this->get_option('add_to_cart_button_id') );
         $this->price_label_id                  = esc_attr( $this->get_option('price_label_id') );
         $this->help_pages                      = $this->get_option('help_pages');
-        $this->recom_engine_home_category_page = esc_attr( $this->get_option('recom_engine_home_category_page') );
+        $this->recom_engine_home_page          = esc_attr( $this->get_option('recom_engine_home_page') );
+        $this->recom_engine_category_page      = esc_attr( $this->get_option('recom_engine_category_page') );
         $this->recom_engine_product_page       = esc_attr( $this->get_option('recom_engine_product_page') );
+        $this->recom_engine_cart_page          = esc_attr( $this->get_option('recom_engine_cart_page'));
         $this->recom_engine_checkout_form      = esc_attr( $this->get_option('recom_engine_checkout_form') );
         $this->recom_engine_thank_you_page     = esc_attr( $this->get_option('recom_engine_thank_you_page') );
         
@@ -49,24 +51,35 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         /*
         * Hooks used for Recommendation Engine
         */
+        // Home Page
+        add_action('woocommerce_archive_description', array($this, 'recom_engine_archive_description_home_page'), 10);
+        add_action('woocommerce_before_shop_loop', array($this, 'recom_engine_before_shop_loop_home_page'), 10);
+        add_action('woocommerce_after_shop_loop', array($this, 'recom_engine_after_shop_loop_home_page'), 10);
 
-        // Home & Category Pages
-        add_action('woocommerce_archive_description', array($this, 'recom_engine_archive_description'), 999);
-        add_action('woocommerce_before_shop_loop', array($this, 'recom_engine_before_shop_loop'), 999);
-        add_action('woocommerce_after_shop_loop', array($this, 'recom_engine_after_shop_loop'), 999);
+        // Category Pages
+        add_action('woocommerce_archive_description', array($this, 'recom_engine_archive_description_category_page'), 10);
+        add_action('woocommerce_before_shop_loop', array($this, 'recom_engine_before_shop_loop_category_page'), 10);
+        add_action('woocommerce_after_shop_loop', array($this, 'recom_engine_after_shop_loop_category_page'), 10);
 
         // Product Pages
-        add_action('woocommerce_before_single_product', array($this, 'recom_engine_before_single_product'), 999);
-        add_action('woocommerce_after_single_product', array($this, 'recom_engine_after_single_product'), 999);
+        add_action('woocommerce_before_single_product', array($this, 'recom_engine_before_single_product'), 10);
+        add_action('woocommerce_after_single_product_summary', array($this, 'recom_engine_after_single_product_summary'), 10);
+
+        // Cart Page
+        add_action('woocommerce_before_cart_table', array($this, 'recom_engine_before_cart_table'), 10);
+        add_action('woocommerce_cart_contents', array($this, 'recom_engine_cart_contents'), 10);
 
         // Checkout Page
-        add_action('woocommerce_before_checkout_form', array($this, 'recom_engine_before_checkout_form'), 999);
-        add_action('woocommerce_after_checkout_form', array($this, 'recom_engine_after_checkout_form'), 999);
-        add_action('woocommerce_before_checkout_registration_form', array($this, 'recom_engine_before_checkout_registration_form'), 999);
-        add_action('woocommerce_after_checkout_registration_form', array($this, 'recom_engine_after_checkout_registration_form'), 999);
+        add_action('woocommerce_before_checkout_form', array($this, 'recom_engine_before_checkout_form'), 10);
+        add_action('woocommerce_after_checkout_form', array($this, 'recom_engine_after_checkout_form'), 10);
+        add_action('woocommerce_before_checkout_registration_form', array($this, 'recom_engine_before_checkout_registration_form'), 10);
+        add_action('woocommerce_after_checkout_registration_form', array($this, 'recom_engine_after_checkout_registration_form'), 10);
 
         // Thank You Page
-        add_action('woocommerce_thankyou', array($this, 'recom_engine_thank_you_page'), 999);
+        add_action('woocommerce_thankyou', array($this, 'recom_engine_thank_you_page'), 10);
+
+        // Search Page
+        // add_filter('posts_search', array($this, 'recom_engine_search_page'), 10);
 
         // Hooks used for JavaScript functions
         add_action('woocommerce_before_main_content', array($this, 'send_category'), 30, 0);
@@ -122,34 +135,46 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
               'title' => __('Add To Cart Button'),
               'description' => __('[Optional] CSS query selector for the button used to add a product to cart.'),
               'type' => 'text',
-              'default' => '.entry-summary .single_add_to_cart_button'
+              'default' => '.entry-summary .single_add_to_cart_button',
             ),
             'price_label_id' => array(
               'title' => __('Price Label'),
               'description' => __('[Optional] CSS query selector for the main product price on a product page.'),
               'type' => 'text',
-              'default' => '.entry-summary .woocommerce-Price-amount'
+              'default' => '.entry-summary .woocommerce-Price-amount',
             ),
             'help_pages' => array(
                 'title' => __('Help Pages'),
                 'description' => __('Select All Help Pages (e.g. How to Order, FAQ, Delivery and Payment, Contact Us)'),
                 'type' => 'multiselect',
-                'options' => $pages
+                'options' => $pages,
             ),
             'webshop_personalization' => array(
                 'title' => __('Webshop Personalization'),
                 'description' => 'Allows the display of customized products carousel on your website pages',
                 'type' => 'title',
             ),
-            'recom_engine_home_category_page' => array(
-                'title' => __('Home & Category Pages'),
-                'description' => __('Enables the display of Recommendation Engine Carousel on your Home page'),
+            'recom_engine_home_page' => array(
+                'title' => __('Home Page'),
+                'description' => __('Enables the display of Recommendation Engine Carousel on your Home Page'),
+                'type' => 'select',
+                'options' => array(
+                    'none' => 'None',
+                    'archive_description' => 'Display in Archive Description (above Products Box Listing)',
+                    'before_shop_loop' => 'Display before Shop Loop (before Products Box Listing',
+                    'after_shop_loop' => 'Display after Shop Loop (after Products Box Listing',
+                ),
+                'default' => 'before_shop_loop',
+            ),
+            'recom_engine_category_page' => array(
+                'title' => __('Category Pages'),
+                'description' => __('Enables the display of Recommendation Engine Carousel on your Category page'),
                 'type' => 'select',
                 'options' => array(
                     'none' => 'None',
                     'archive_description' => 'Display in Archive Description (above Products Box Listing',
                     'before_shop_loop' => 'Display before Shop Loop (before Products Box Listing)',
-                    'after_shop_loop' => 'Display after Shop Loop (after Products Box Listing)'
+                    'after_shop_loop' => 'Display after Shop Loop (after Products Box Listing)',
                 ),
                 'default' => 'before_shop_loop',
             ),
@@ -160,11 +185,23 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                 'options' => array(
                     'none' => 'None',
                     'before_single_product' => 'Display before Single Product',
-                    'after_single_product' => 'Display after Single Product'
+                    'after_single_product_summary' => 'Display after Single Product Summary',
                 ),
+                'default' => 'after_single_product',
+            ),
+            'recom_engine_cart_page' => array(
+                'title' => __('Cart Page'),
+                'description' => __('Enables the display of Recommendation Engine Carousel on Checkout page'),
+                'type' => 'select',
+                'options' => array(
+                    'none' => 'None',
+                    'before_cart_table' => 'Display before Cart Table',
+                    'after_cart_contents' => 'Display after Cart Contents',
+                ),
+                'default' => 'after_cart_contents',
             ),
             'recom_engine_checkout_form' => array(
-                'title' => __('Checkout Pages'),
+                'title' => __('Checkout Page'),
                 'description' => __('Enables the display of Recommendation Engine Carousel on Checkout page'),
                 'type' => 'select',
                 'options' => array(
@@ -172,14 +209,15 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                     'before_checkout_form' => 'Display before Checkout form',
                     'after_checkout_form' => 'Display after Checkout form',
                     'before_checkout_registration_form' => 'Display before Checkout Registration Form',
-                    'after_checkout_registration_form' => 'Display after Checkout Registration Form'
+                    'after_checkout_registration_form' => 'Display after Checkout Registration Form',
                 ),
+                'default' => 'after_checkout_form',
             ),
             'recom_engine_thank_you_page' => array(
                 'title' => __('Thank You Page'),
                 'description' => __('Enables the display of Recommendation Engine Carousel on Thank You page'),
                 'type' => 'checkbox',
-                'default' => 'yes'
+                'default' => 'yes',
             ),
         );
     }
@@ -216,32 +254,62 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     }
 
     /*
-    * Recommendation Engine for After Shop Loop - Home Page
+    * Recommendation Engine for Archive Description - Home Page
     */
-    public function recom_engine_after_shop_loop()
+    public function recom_engine_archive_description_home_page()
     {
-        if ( $this->recom_engine_home_category_page == 'after_shop_loop' ) {
-            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ( $this->recom_engine_home_page == 'archive_description' && !is_product_category() ) {
+            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>'; 
         }
     }
 
     /*
     * Recommendation Engine for Before Shop Loop - Home Page
     */
-    public function recom_engine_before_shop_loop()
+    public function recom_engine_before_shop_loop_home_page()
     {
-        if ( $this->recom_engine_home_category_page == 'before_shop_loop' ) {
+        if ( $this->recom_engine_home_page == 'before_shop_loop' && !is_product_category() ) {
             echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }
 
     /*
-    * Recommendation Engine for Archive Description - Home Page
+    * Recommendation Engine for After Shop Loop - Home Page
     */
-    public function recom_engine_archive_description()
+    public function recom_engine_after_shop_loop_home_page()
     {
-        if ( $this->recom_engine_home_category_page == 'archive_description' ) {
+        if ( $this->recom_engine_home_page == 'after_shop_loop' && !is_product_category() ) {
             echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for After Shop Loop - Category Page
+    */
+    public function recom_engine_after_shop_loop_category_page()
+    {
+        if ( $this->recom_engine_category_page == 'after_shop_loop' && is_product_category() ) {
+            echo '<div id="retargeting-recommeng-category-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for Before Shop Loop - Category Page
+    */
+    public function recom_engine_before_shop_loop_category_page()
+    {
+        if ( $this->recom_engine_category_page == 'before_shop_loop' && is_product_category() ) {
+            echo '<div id="retargeting-recommeng-category-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for Archive Description - Category Page
+    */
+    public function recom_engine_archive_description_category_page()
+    {
+        if ( $this->recom_engine_category_page == 'archive_description' && is_product_category() ) {
+            echo '<div id="retargeting-recommeng-category-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }
 
@@ -259,10 +327,30 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     /*
     * Recommendation Engine for Afer Single Product
     */
-    public function recom_engine_after_single_product()
+    public function recom_engine_after_single_product_summary()
     {
-        if ( $this->recom_engine_product_page == 'after_single_product' ) {
+        if ( $this->recom_engine_product_page == 'after_single_product_summary' ) {
             echo '<div id="retargeting-recommeng-product-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for before Cart Table - Cart Page
+    */
+    public function recom_engine_before_cart_table()
+    {
+        if ( $this->recom_engine_cart_page == 'before_cart_table' ) {
+            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for before Cart Contents - Cart Page
+    */
+    public function recom_engine_cart_contents()
+    {
+        if ( $this->recom_engine_cart_page == 'after_cart_contents' ) {
+            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }
 
@@ -315,6 +403,20 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
             echo '<div id="retargeting-recommeng-thank-you-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }
+
+    /*
+    * Recommendation Engine for Search Page
+    */
+    // public function recom_engine_search_page( $content )
+    // {
+    //     global $wp_query;
+        
+    //     if ( isset($wp_query->query) && is_search() ) {
+    //         return $content . '<p>RETARGETING - I\'m filtering the content inside the main loop</p>';
+    //     }
+
+    //     return $content;
+    // }
 
     /*
     * setEmail

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -22,23 +22,22 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     */
     public function __construct()
     {
-        $this->id = 'retargeting';
-        $this->method_title = "Retargeting Tracker";
+        $this->id                 = 'retargeting';
+        $this->method_title       = "Retargeting Tracker";
         $this->method_description = __('Retargeting.Biz is a marketing automation tool that boosts the conversion rate and sales of your online store.');
 
         $this->init_form_fields();
         $this->init_settings();
 
-        $this->domain_api_key = $this->get_option('domain_api_key');
-        $this->token = $this->get_option('token');
-        $this->add_to_cart_button_id = $this->get_option('add_to_cart_button_id');
-        $this->price_label_id = $this->get_option('price_label_id');
-        $this->help_pages = $this->get_option('help_pages');
+        $this->domain_api_key                  = $this->get_option('domain_api_key');
+        $this->token                           = $this->get_option('token');
+        $this->add_to_cart_button_id           = $this->get_option('add_to_cart_button_id');
+        $this->price_label_id                  = $this->get_option('price_label_id');
+        $this->help_pages                      = $this->get_option('help_pages');
         $this->recom_engine_home_category_page = $this->get_option('recom_engine_home_category_page');
-        $this->recom_engine_product_page = $this->get_option('recom_engine_product_page');
-        $this->recom_engine_checkout_form = $this->get_option('recom_engine_checkout_form');
-        $this->recom_engine_thank_you_page = $this->get_option('recom_engine_thank_you_page');
-        // var_dump($this->recom_engine_thank_you_page);
+        $this->recom_engine_product_page       = $this->get_option('recom_engine_product_page');
+        $this->recom_engine_checkout_form      = $this->get_option('recom_engine_checkout_form');
+        $this->recom_engine_thank_you_page     = $this->get_option('recom_engine_thank_you_page');
         
         add_action('init', array($this, 'ra_session_init'), 1);
 
@@ -68,9 +67,6 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
 
         // Thank You Page
         add_action('woocommerce_thankyou', array($this, 'recom_engine_thank_you_page'), 999);
-
-        // Search Form
-        add_action('woocommerce_pre_get_product_search_form', array($this, 'recom_engine_pre_get_product_search_form'), 999);
 
         // Hooks used for JavaScript functions
         add_action('woocommerce_before_main_content', array($this, 'send_category'), 30, 0);
@@ -112,13 +108,13 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         $this->form_fields = array(
             'domain_api_key' => array(
                 'title' => __('Tracking API KEY'),
-                'description' => __('Insert Retargeting Tracking API Key. <a href="https://retargeting.biz/admin?action=api_redirect&token=5ac66ac466f3e1ec5e6fe5a040356997" target="_blank" rel="noopener noreferrer">Click here</a> to get your Tracking API Key'),
+                'description' => __('Insert Retargeting Tracking API Key. <a href=' . esc_url('https://retargeting.biz/') . ' ' . 'target="_blank" rel="noopener noreferrer">Click here</a> to get your Tracking API Key'),
                 'type' => 'text',
                 'default' => '',
             ),
             'token' => array(
                 'title' => __('REST API Key'),
-                'description' => __('Insert Retargeting REST API Key. <a href="https://retargeting.biz/admin?action=api_redirect&token=5ac66ac466f3e1ec5e6fe5a040356997" target="_blank" rel="noopener noreferrer">Click here</a> to get your Rest API Key'),
+                'description' => __('Insert Retargeting REST API Key. <a href=' . esc_url('https://retargeting.biz/') . ' ' . 'target="_blank" rel="noopener noreferrer">Click here</a> to get your Rest API Key'),
                 'type' => 'text',
                 'default' => '',
             ),
@@ -252,6 +248,7 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     /*
     * Recommendation Engine for Before Single Product
     */
+
     public function recom_engine_before_single_product()
     {
         if ( $this->recom_engine_product_page == 'before_single_product' ) {
@@ -317,11 +314,6 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         if ( $this->recom_engine_thank_you_page == 'yes') {
             echo '<div id="retargeting-recommeng-thank-you-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
-    }
-
-    public function recom_engine_pre_get_product_search_form()
-    {
-        echo '<div id="retargeting-recommeng-search-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
     }
 
     /*

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -35,6 +35,7 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         $this->price_label_id = $this->get_option('price_label_id');
         $this->help_pages = $this->get_option('help_pages');
         $this->recom_engine = $this->get_option('recom_engine');
+        $this->recom_engine_test = $this->get_option('recom_engine_test');
         
         add_action('init', array($this, 'ra_session_init'));
 
@@ -132,10 +133,30 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                 'options' => $pages
             ),
             'recom_engine' => array(
-                'title' => _('Recommendation Engine'),
+                'title' => __('Recommendation Engine'),
                 'description' => _('Select where to display products selected by A.I'),
                 'type' => 'multiselect',
                 'options' => $recomEngineArr
+            ),
+            'webshop_personalization' => array(
+                'title' => __( 'Webshop Personalization' ),
+                'description' => 'Placeholder Text',
+                'type' => 'title',
+            ),
+            'recom_engine_home_page' => array(
+                'title' => __('Recommendation Engine Test'),
+                'label' => __('Display Recommendation Engine on Home Page'),
+                'description' => __('Enables the display of Recommendation Engine Carousel on your Home page'),
+                'type' => 'checkbox',
+                'options' => array('test1' => 'sal1', 'test2' => 'sal2'),
+                'checkboxgroup' => 'start',
+                'default' => 'yes'
+            ),
+            'recom_engine_category_page' => array(
+                'label' => __("Display Recommendation Engine on Category page"),
+                'description' => __("Enables the display of Recommendation Engine Carousel on your Category page"),
+                'type' => 'select',
+                'options' => array('test1' => 'sal1', 'test2' => 'sal2'),
             ),
         );
     }

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -69,6 +69,9 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         // Thank You Page
         add_action('woocommerce_thankyou', array($this, 'recom_engine_thank_you_page'), 999);
 
+        // Search Form
+        add_action('woocommerce_pre_get_product_search_form', array($this, 'recom_engine_pre_get_product_search_form'), 999);
+
         // Hooks used for JavaScript functions
         add_action('woocommerce_before_main_content', array($this, 'send_category'), 30, 0);
 
@@ -80,8 +83,6 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         add_action( 'woocommerce_after_mini_cart', array($this, 'remove_from_cart' ));
 
         add_action('woocommerce_before_single_product', array($this, 'click_image'), 30, 0);
-
-        add_action('woocommerce_before_single_product', array($this, 'like_facebook'), 50, 0);
 
         add_action('wp_footer', array($this, 'help_pages'), 999, 0);
 
@@ -316,6 +317,11 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         if ( $this->recom_engine_thank_you_page == 'yes') {
             echo '<div id="retargeting-recommeng-thank-you-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
+    }
+
+    public function recom_engine_pre_get_product_search_form()
+    {
+        echo '<div id="retargeting-recommeng-search-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
     }
 
     /*
@@ -563,21 +569,6 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     }
 
     /*
-    * likeFacebook
-    */
-    public function like_facebook()
-    {
-        global $product;
-        echo "<script>
-            if (typeof FB != 'undefined') {
-                FB.Event.subscribe('edge.create', function () {
-                    _ra.likeFacebook(" . $product->get_id() . ");
-                });
-            };
-        </script>";
-    }
-
-    /*
     * saveOrder
     */
     public function save_order($order_id)
@@ -679,19 +670,21 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     public function help_pages()
     {
         global $post;
-        $page = $post->post_name;
-        if (!empty($this->help_pages)) {
-            if (in_array($page, $this->help_pages)) {
-                echo "<script>
-                    var _ra = _ra || {};
-                        _ra.visitHelpPageInfo = {
-                            'visit' : true
-                        }
-    
-                        if (_ra.ready !== undefined) {
-                            _ra.visitHelpPage();
-                        }
-                </script>";
+        if ($post) {
+            $page = $post->post_name;
+            if (!empty($this->help_pages)) {
+                if (in_array($page, $this->help_pages)) {
+                    echo "<script>
+                        var _ra = _ra || {};
+                            _ra.visitHelpPageInfo = {
+                                'visit' : true
+                            }
+        
+                            if (_ra.ready !== undefined) {
+                                _ra.visitHelpPage();
+                            }
+                    </script>";
+                }
             }
         }
     }

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -34,11 +34,12 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         $this->add_to_cart_button_id = $this->get_option('add_to_cart_button_id');
         $this->price_label_id = $this->get_option('price_label_id');
         $this->help_pages = $this->get_option('help_pages');
+        $this->recom_engine_home_page = $this->get_option('recom_engine_home_page');
         $this->recom_engine_checkout_form = $this->get_option('recom_engine_checkout_form');
         $this->recom_engine_category_page = $this->get_option('recom_engine_category_page');
-        var_dump($this->recom_engine_category_page);
+        var_dump($this->recom_engine_home_page);
         
-        add_action('init', array($this, 'ra_session_init'));
+        add_action('init', array($this, 'ra_session_init'), 1);
 
         add_action('woocommerce_update_options_integration_retargeting', array($this, 'process_admin_options'));
 
@@ -49,14 +50,19 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         * Hooks used for Recommendation Engine
         */
 
+        // Home Page
+        add_action('woocommerce_before_main_content', array($this, 'recom_engine_before_main_content'), 999);
+        add_action('woocommerce_after_main_content', array($this, 'recom_engine_after_main_content'), 999);
+        add_action('woocommerce_archive_description', array($this, 'recom_engine_archive_description'), 999);
+        add_action('woocommerce_before_shop_loop', array($this, 'recom_engine_before_shop_loop'), 999);
+        add_action('woocommerce_after_shop_loop', array($this, 'recom_engine_after_shop_loop'), 999);
+
         // Category Page
         add_action('woocommerce_after_subcategory', array($this, 'recom_engine_after_subcategory'), 999);
 
         // Checkout Page
         add_action('woocommerce_before_checkout_form', array($this, 'recom_engine_before_checkout_form'), 999);
         add_action('woocommerce_after_checkout_form', array($this, 'recom_engine_after_checkout_form'), 999);
-        add_action('woocommerce_before_checkout_billing_form', array($this, 'recom_engine_before_checkout_billing_form'), 999);
-        add_action('woocommerce_after_checkout_billing_form', array($this, 'recom_engine_after_checkout_billing_form'), 999);
         add_action('woocommerce_before_checkout_registration_form', array($this, 'recom_engine_before_checkout_registration_form'), 999);
         add_action('woocommerce_after_checkout_registration_form', array($this, 'recom_engine_after_checkout_registration_form'), 999);
 
@@ -99,20 +105,6 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
             $pages[$page->post_name] = $page->post_title;
         }
 
-        // Recommendation Engine customization areas
-        $recomEngineArr = array(
-            'none'                      => 'None',
-            'home_page'                 => 'Home Page',
-            'category_page'             => 'Category Page',
-            'product_page'              => 'Product Page',
-            'checkout_page_before_form' => 'Checkout Page - Before Form',
-            'checkout_page_after_form'  => 'Checkout Page - After Form',
-            'thank_you_page'            => 'Thank You Page',
-            'out_of_stock'              => 'Out of Stock Page',
-            'search_page'               => 'Search Page',
-            '404_page'                  => '404 Page'
-        );
-
         $this->form_fields = array(
             'domain_api_key' => array(
                 'title' => __('Tracking API KEY'),
@@ -145,7 +137,7 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                 'options' => $pages
             ),
             'webshop_personalization' => array(
-                'title' => __( 'Webshop Personalization' ),
+                'title' => __('Webshop Personalization'),
                 'description' => 'Allows the display of customized products carousel on your website pages',
                 'type' => 'title',
             ),
@@ -153,15 +145,20 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                 'title' => __('Home Page'),
                 'label' => __('Display on Home Page'),
                 'description' => __('Enables the display of Recommendation Engine Carousel on your Home page'),
-                'type' => 'checkbox',
-                'options' => array('test1' => 'sal1', 'test2' => 'sal2'),
-                'checkboxgroup' => 'start',
-                'default' => 'yes'
+                'type' => 'select',
+                'options' => array(
+                    'none' => 'None',
+                    'before_main_content' => 'Display before Main Content',
+                    'after_main_content' => 'Display after Main Content',
+                    'archive_description' => 'Display in Archive Description',
+                    'before_shop_loop' => 'Display before Shop Loop',
+                    'after_shop_loop' => 'Display after Shop Loop'
+                ),
             ),
             'recom_engine_category_page' => array(
-                'title' => __("Category Page"),
-                'label' => __("Display Recommendation Engine on Category page"),
-                'description' => __("Enables the display of Recommendation Engine Carousel on your Category page"),
+                'title' => __('Category Page'),
+                'label' => __('Display Recommendation Engine on Category page'),
+                'description' => __('Enables the display of Recommendation Engine Carousel on your Category page'),
                 'type' => 'select',
                 'options' => array(
                     'none' => 'None',
@@ -170,16 +167,14 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                 ),
             ),
             'recom_engine_checkout_form' => array(
-                'title' => __("Checkout Page"),
-                'label' => __("Display Recommendation Engine on Checkout page"),
-                'description' => __("Enables the display of Recommendation Engine Carousel on Checkout page"),
+                'title' => __('Checkout Page'),
+                'label' => __('Display Recommendation Engine on Checkout page'),
+                'description' => __('Enables the display of Recommendation Engine Carousel on Checkout page'),
                 'type' => 'select',
                 'options' => array(
                     'none' => 'None',
                     'before_checkout_form' => 'Display before Checkout form',
                     'after_checkout_form' => 'Display after Checkout form',
-                    'before_checkout_billing_form' => 'Display before Checkout Billing Form',
-                    'after_checkout_billing_form' => 'Display after Checkout Billing Form',
                     'before_checkout_registration_form' => 'Display before Checkout Registration Form',
                     'after_checkout_registration_form' => 'Display after Checkout Registration Form'
                 ),
@@ -219,6 +214,56 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     }
 
     /*
+    * Recommendation Engine for Before Main Content - Home Page
+    */
+    public function recom_engine_before_main_content()
+    {
+        if ( $this->recom_engine_home_page == 'before_main_content' ) {
+            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for Before Main Content - Home Page
+    */
+    public function recom_engine_after_main_content()
+    {
+        if ( $this->recom_engine_home_page == 'after_main_content' ) {
+            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for After Shop Loop - Home Page
+    */
+    public function recom_engine_after_shop_loop()
+    {
+        if ( $this->recom_engine_home_page == 'after_shop_loop' ) {
+            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for Before Shop Loop - Home Page
+    */
+    public function recom_engine_before_shop_loop()
+    {
+        if ( $this->recom_engine_home_page == 'before_shop_loop' ) {
+            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for Archive Description - Home Page
+    */
+    public function recom_engine_archive_description()
+    {
+        if ( $this->recom_engine_home_page == 'archive_description' ) {
+            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
     * Recommendation Engine for After Subcategory
     */
     public function recom_engine_after_subcategory()
@@ -244,24 +289,6 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     public function recom_engine_after_checkout_form()
     {
         if ( $this->recom_engine_checkout_form == 'after_checkout_form' ) {
-            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
-        }
-    }
-
-    /*
-    * Recommendation Engine for Before Checkout Billing Form
-    */
-    public function recom_engine_before_checkout_billing_form() {
-        if ( $this->recom_engine_checkout_form == 'before_checkout_billing_form' ) {
-            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
-        }
-    }
-
-    /*
-    * Recommendation Engine for After Checkout Billing Form
-    */
-    public function recom_engine_after_checkout_billing_form() {
-        if ( $this->recom_engine_checkout_form == 'after_checkout_billing_form' ) {
             echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -34,8 +34,8 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         $this->add_to_cart_button_id = $this->get_option('add_to_cart_button_id');
         $this->price_label_id = $this->get_option('price_label_id');
         $this->help_pages = $this->get_option('help_pages');
-        $this->recom_engine = $this->get_option('recom_engine');
-        $this->recom_engine_test = $this->get_option('recom_engine_test');
+        $this->recom_engine_checkout_form = $this->get_option('recom_engine_checkout_form');
+        var_dump($this->recom_engine_checkout_form);
         
         add_action('init', array($this, 'ra_session_init'));
 
@@ -132,20 +132,14 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                 'type' => 'multiselect',
                 'options' => $pages
             ),
-            'recom_engine' => array(
-                'title' => __('Recommendation Engine'),
-                'description' => _('Select where to display products selected by A.I'),
-                'type' => 'multiselect',
-                'options' => $recomEngineArr
-            ),
             'webshop_personalization' => array(
                 'title' => __( 'Webshop Personalization' ),
-                'description' => 'Placeholder Text',
+                'description' => 'Allows you to display a customized products carousel',
                 'type' => 'title',
             ),
             'recom_engine_home_page' => array(
-                'title' => __('Recommendation Engine Test'),
-                'label' => __('Display Recommendation Engine on Home Page'),
+                'title' => __('Home Page'),
+                'label' => __('Display on Home Page'),
                 'description' => __('Enables the display of Recommendation Engine Carousel on your Home page'),
                 'type' => 'checkbox',
                 'options' => array('test1' => 'sal1', 'test2' => 'sal2'),
@@ -153,10 +147,26 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                 'default' => 'yes'
             ),
             'recom_engine_category_page' => array(
+                'title' => __("Category Page"),
                 'label' => __("Display Recommendation Engine on Category page"),
                 'description' => __("Enables the display of Recommendation Engine Carousel on your Category page"),
                 'type' => 'select',
-                'options' => array('test1' => 'sal1', 'test2' => 'sal2'),
+                'options' => array(
+                    'none' => 'None',
+                    'test1' => 'sal1', 
+                    'test2' => 'sal2'
+                ),
+            ),
+            'recom_engine_checkout_form' => array(
+                'title' => __("Checkout Page"),
+                'label' => __("Display Recommendation Engine on Checkout page"),
+                'description' => __("Enables the display of Recommendation Engine Carousel on Checkout page"),
+                'type' => 'select',
+                'options' => array(
+                    'none' => 'None',
+                    'before_checkout_form' => 'Display before Checkout form',
+                    'after_checkout_form' => 'Display after Checkout form',
+                ),
             ),
         );
     }
@@ -197,8 +207,8 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     */
     public function recom_engine_before_checkout_form()
     {
-        if (in_array('checkout_page_before_form', $this->recom_engine)) {
-            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ( $this->recom_engine_checkout_form == 'before_checkout_form' ) {
+            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }
 
@@ -207,8 +217,8 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     */
     public function recom_engine_after_checkout_form()
     {
-        if (in_array('checkout_page_after_form', $this->recom_engine)) {
-            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ( $this->recom_engine_checkout_form == 'after_checkout_form' ) {
+            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }
 

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -42,8 +42,12 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
 
         add_action('wp_head', array($this, 'get_retargeting_tracking_code'), 999);
         add_action('wp_head', array($this, 'set_email'), 9999);
-        add_action('woocommerce_after_checkout_form', array($this, 'recom_engine_checkout_form'), 999);
 
+        // Hooks used for Recommendation Engine
+        add_action('woocommerce_before_checkout_form', array($this, 'recom_engine_before_checkout_form'), 999);
+        add_action('woocommerce_after_checkout_form', array($this, 'recom_engine_after_checkout_form'), 999);
+
+        // Hooks used for JavaScript functions
         add_action('woocommerce_before_main_content', array($this, 'send_category'), 30, 0);
 
         add_action('woocommerce_before_single_product', array($this, 'send_product'), 20, 0);
@@ -84,15 +88,16 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
 
         // Recommendation Engine customization areas
         $recomEngineArr = array(
-            'none' => 'None',
-            'home_page' => 'Home Page',
-            'category_page' => 'Category Page',
-            'product_page' => 'Product Page',
-            'checkout_page' => 'Checkout Page',
-            'thank_you_page' => 'Thank You Page',
-            'out_of_stock' => 'Out of Stock Page',
-            'search_page' => 'Search Page',
-            '404_page' => '404 Page'
+            'none'                      => 'None',
+            'home_page'                 => 'Home Page',
+            'category_page'             => 'Category Page',
+            'product_page'              => 'Product Page',
+            'checkout_page_before_form' => 'Checkout Page - Before Form',
+            'checkout_page_after_form'  => 'Checkout Page - After Form',
+            'thank_you_page'            => 'Thank You Page',
+            'out_of_stock'              => 'Out of Stock Page',
+            'search_page'               => 'Search Page',
+            '404_page'                  => '404 Page'
         );
 
         $this->form_fields = array(
@@ -166,10 +171,22 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         <!-- Retargeting Tracking Code -->';
     }
 
-
-    public function recom_engine_checkout_form()
+    /*
+    * Recommendation Engine for Before Checkout Form
+    */
+    public function recom_engine_before_checkout_form()
     {
-        if (in_array('checkout_page', $this->recom_engine)) {
+        if (in_array('checkout_page_before_form', $this->recom_engine)) {
+            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for After Checkout Form
+    */
+    public function recom_engine_after_checkout_form()
+    {
+        if (in_array('checkout_page_after_form', $this->recom_engine)) {
             echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -173,10 +173,10 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                 'options' => array(
                     'none' => 'None',
                     'archive_description' => 'Display in Archive Description (above Products Box Listing',
-                    'before_shop_loop' => 'Display before Shop Loop (before Products Box Listing)',
-                    'after_shop_loop' => 'Display after Shop Loop (after Products Box Listing)',
+                    'category_before_shop_loop' => 'Display before Shop Loop (before Products Box Listing)',
+                    'category_after_shop_loop' => 'Display after Shop Loop (after Products Box Listing)',
                 ),
-                'default' => 'before_shop_loop',
+                'default' => 'category_before_shop_loop',
             ),
             'recom_engine_product_page' => array(
                 'title' => __('Product Pages'),
@@ -187,7 +187,7 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                     'before_single_product' => 'Display before Single Product',
                     'after_single_product_summary' => 'Display after Single Product Summary',
                 ),
-                'default' => 'after_single_product',
+                'default' => 'after_single_product_summary',
             ),
             'recom_engine_cart_page' => array(
                 'title' => __('Cart Page'),
@@ -268,7 +268,7 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     */
     public function recom_engine_before_shop_loop_home_page()
     {
-        if ( $this->recom_engine_home_page == 'before_shop_loop' && !is_product_category() ) {
+        if ( $this->recom_engine_home_page == 'category_before_shop_loop' && !is_product_category() ) {
             echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }
@@ -278,7 +278,7 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     */
     public function recom_engine_after_shop_loop_home_page()
     {
-        if ( $this->recom_engine_home_page == 'after_shop_loop' && !is_product_category() ) {
+        if ( $this->recom_engine_home_page == 'category_after_shop_loop' && !is_product_category() ) {
             echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -42,7 +42,7 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
 
         add_action('wp_head', array($this, 'get_retargeting_tracking_code'), 999);
         add_action('wp_head', array($this, 'set_email'), 9999);
-        add_action('woocommerce_after_checkout_form', array($this, 'recom_engine_head'), 999);
+        add_action('woocommerce_after_checkout_form', array($this, 'recom_engine_checkout_form'), 999);
 
         add_action('woocommerce_before_main_content', array($this, 'send_category'), 30, 0);
 
@@ -74,10 +74,11 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     */
     function init_form_fields()
     {
-        //List all pages
-        $allpages = get_pages();
+        // List all pages
+        $allPages = get_pages();
         $pages = array();
-        foreach ($allpages as $key => $page) {
+        foreach ($allPages as $key => $page) {
+            $pages['ra_none']        = 'None';
             $pages[$page->post_name] = $page->post_title;
         }
 
@@ -121,7 +122,7 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
             ),
             'help_pages' => array(
                 'title' => __('Help Pages'),
-                'description' => __('Select All Help Pages (e.g. How to order?, FAQ, How I get the products?)'),
+                'description' => __('Select All Help Pages (e.g. How to Order, FAQ, Delivery and Payment, Contact Us)'),
                 'type' => 'multiselect',
                 'options' => $pages
             ),
@@ -166,9 +167,11 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     }
 
 
-    public function recom_engine_head()
+    public function recom_engine_checkout_form()
     {
-        echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if (in_array('checkout_page', $this->recom_engine)) {
+            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
     }
 
     /*

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -35,7 +35,8 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         $this->price_label_id = $this->get_option('price_label_id');
         $this->help_pages = $this->get_option('help_pages');
         $this->recom_engine_checkout_form = $this->get_option('recom_engine_checkout_form');
-        var_dump($this->recom_engine_checkout_form);
+        $this->recom_engine_category_page = $this->get_option('recom_engine_category_page');
+        var_dump($this->recom_engine_category_page);
         
         add_action('init', array($this, 'ra_session_init'));
 
@@ -44,9 +45,20 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         add_action('wp_head', array($this, 'get_retargeting_tracking_code'), 999);
         add_action('wp_head', array($this, 'set_email'), 9999);
 
-        // Hooks used for Recommendation Engine
+        /*
+        * Hooks used for Recommendation Engine
+        */
+
+        // Category Page
+        add_action('woocommerce_after_subcategory', array($this, 'recom_engine_after_subcategory'), 999);
+
+        // Checkout Page
         add_action('woocommerce_before_checkout_form', array($this, 'recom_engine_before_checkout_form'), 999);
         add_action('woocommerce_after_checkout_form', array($this, 'recom_engine_after_checkout_form'), 999);
+        add_action('woocommerce_before_checkout_billing_form', array($this, 'recom_engine_before_checkout_billing_form'), 999);
+        add_action('woocommerce_after_checkout_billing_form', array($this, 'recom_engine_after_checkout_billing_form'), 999);
+        add_action('woocommerce_before_checkout_registration_form', array($this, 'recom_engine_before_checkout_registration_form'), 999);
+        add_action('woocommerce_after_checkout_registration_form', array($this, 'recom_engine_after_checkout_registration_form'), 999);
 
         // Hooks used for JavaScript functions
         add_action('woocommerce_before_main_content', array($this, 'send_category'), 30, 0);
@@ -134,7 +146,7 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
             ),
             'webshop_personalization' => array(
                 'title' => __( 'Webshop Personalization' ),
-                'description' => 'Allows you to display a customized products carousel',
+                'description' => 'Allows the display of customized products carousel on your website pages',
                 'type' => 'title',
             ),
             'recom_engine_home_page' => array(
@@ -153,7 +165,7 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                 'type' => 'select',
                 'options' => array(
                     'none' => 'None',
-                    'test1' => 'sal1', 
+                    'after_subcategory' => 'Display after Subcategory', 
                     'test2' => 'sal2'
                 ),
             ),
@@ -166,6 +178,10 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                     'none' => 'None',
                     'before_checkout_form' => 'Display before Checkout form',
                     'after_checkout_form' => 'Display after Checkout form',
+                    'before_checkout_billing_form' => 'Display before Checkout Billing Form',
+                    'after_checkout_billing_form' => 'Display after Checkout Billing Form',
+                    'before_checkout_registration_form' => 'Display before Checkout Registration Form',
+                    'after_checkout_registration_form' => 'Display after Checkout Registration Form'
                 ),
             ),
         );
@@ -203,6 +219,16 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     }
 
     /*
+    * Recommendation Engine for After Subcategory
+    */
+    public function recom_engine_after_subcategory()
+    {
+        if ( $this->recom_engine_after_subcategory == 'after_subcategory' ) {
+            echo '<div id="retargeting-recommeng-category-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
     * Recommendation Engine for Before Checkout Form
     */
     public function recom_engine_before_checkout_form()
@@ -218,6 +244,42 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     public function recom_engine_after_checkout_form()
     {
         if ( $this->recom_engine_checkout_form == 'after_checkout_form' ) {
+            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for Before Checkout Billing Form
+    */
+    public function recom_engine_before_checkout_billing_form() {
+        if ( $this->recom_engine_checkout_form == 'before_checkout_billing_form' ) {
+            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for After Checkout Billing Form
+    */
+    public function recom_engine_after_checkout_billing_form() {
+        if ( $this->recom_engine_checkout_form == 'after_checkout_billing_form' ) {
+            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for After Checkout Registration Form
+    */
+    public function recom_engine_before_checkout_registration_form() {
+        if ( $this->recom_engine_checkout_form == 'before_checkout_registration_form' ) {
+            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for After Checkout Registration Form
+    */
+    public function recom_engine_after_checkout_registration_form() {
+        if ( $this->recom_engine_checkout_form == 'after_checkout_registration_form' ) {
             echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -34,15 +34,15 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         $this->add_to_cart_button_id = $this->get_option('add_to_cart_button_id');
         $this->price_label_id = $this->get_option('price_label_id');
         $this->help_pages = $this->get_option('help_pages');
+        $this->recom_engine = $this->get_option('recom_engine');
         
         add_action('init', array($this, 'ra_session_init'));
 
         add_action('woocommerce_update_options_integration_retargeting', array($this, 'process_admin_options'));
 
         add_action('wp_head', array($this, 'get_retargeting_tracking_code'), 999);
-
         add_action('wp_head', array($this, 'set_email'), 9999);
-
+        add_action('woocommerce_after_checkout_form', array($this, 'recom_engine_head'), 999);
 
         add_action('woocommerce_before_main_content', array($this, 'send_category'), 30, 0);
 
@@ -74,13 +74,25 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     */
     function init_form_fields()
     {
-        // List all pages
-        $allPages = get_pages();
+        //List all pages
+        $allpages = get_pages();
         $pages = array();
-        foreach ($allPages as $key => $page) {
-            $pages['ra_none'] = 'None';
+        foreach ($allpages as $key => $page) {
             $pages[$page->post_name] = $page->post_title;
         }
+
+        // Recommendation Engine customization areas
+        $recomEngineArr = array(
+            'none' => 'None',
+            'home_page' => 'Home Page',
+            'category_page' => 'Category Page',
+            'product_page' => 'Product Page',
+            'checkout_page' => 'Checkout Page',
+            'thank_you_page' => 'Thank You Page',
+            'out_of_stock' => 'Out of Stock Page',
+            'search_page' => 'Search Page',
+            '404_page' => '404 Page'
+        );
 
         $this->form_fields = array(
             'domain_api_key' => array(
@@ -109,9 +121,15 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
             ),
             'help_pages' => array(
                 'title' => __('Help Pages'),
-                'description' => __('Select All Help Pages (e.g. How to Order, FAQ, Delivery and Payment, Contact Us)'),
+                'description' => __('Select All Help Pages (e.g. How to order?, FAQ, How I get the products?)'),
                 'type' => 'multiselect',
                 'options' => $pages
+            ),
+            'recom_engine' => array(
+                'title' => _('Recommendation Engine'),
+                'description' => _('Select where to display products selected by A.I'),
+                'type' => 'multiselect',
+                'options' => $recomEngineArr
             ),
         );
     }
@@ -145,6 +163,12 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         var s = document.getElementsByTagName("script")[0]; s.parentNode.insertBefore(ra,s);})();
         </script>
         <!-- Retargeting Tracking Code -->';
+    }
+
+
+    public function recom_engine_head()
+    {
+        echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
     }
 
     /*

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -908,9 +908,15 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         $min_price = current($prices['sale_price']);
         $max_price = end($prices['regular_price']);
         $price = $min_price !== $max_price ? $max_price : $min_price;
-        $specialPrice = $min_price !== $max_price ? $min_price : 0;
+        $specialPrice = 0;
+
+        if ($product->is_on_sale()) {
+            $specialPrice = $product->get_sale_price();
+        }
+
         $price = wc_get_price_including_tax($product, array('price' => $price));
         $specialPrice = wc_get_price_including_tax($product, array('price' => $specialPrice));
+
         return array(
             (!empty($price) ? $price : 0),
             (!empty($specialPrice) ? $specialPrice : 0)
@@ -930,6 +936,7 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         $specialPrice = (!empty($getSpecialPrice) ? $getSpecialPrice : 0);
         $price = wc_get_price_including_tax($product, array('price' => $price));
         $specialPrice = wc_get_price_including_tax($product, array('price' => $specialPrice));
+
         return array(
             (!empty($price) ? $price : 0),
             (!empty($specialPrice) ? $specialPrice : 0)

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -34,10 +34,11 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         $this->add_to_cart_button_id = $this->get_option('add_to_cart_button_id');
         $this->price_label_id = $this->get_option('price_label_id');
         $this->help_pages = $this->get_option('help_pages');
-        $this->recom_engine_home_page = $this->get_option('recom_engine_home_page');
+        $this->recom_engine_home_category_page = $this->get_option('recom_engine_home_category_page');
+        $this->recom_engine_product_page = $this->get_option('recom_engine_product_page');
         $this->recom_engine_checkout_form = $this->get_option('recom_engine_checkout_form');
-        $this->recom_engine_category_page = $this->get_option('recom_engine_category_page');
-        var_dump($this->recom_engine_home_page);
+        $this->recom_engine_thank_you_page = $this->get_option('recom_engine_thank_you_page');
+        // var_dump($this->recom_engine_thank_you_page);
         
         add_action('init', array($this, 'ra_session_init'), 1);
 
@@ -50,21 +51,23 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         * Hooks used for Recommendation Engine
         */
 
-        // Home Page
-        add_action('woocommerce_before_main_content', array($this, 'recom_engine_before_main_content'), 999);
-        add_action('woocommerce_after_main_content', array($this, 'recom_engine_after_main_content'), 999);
+        // Home & Category Pages
         add_action('woocommerce_archive_description', array($this, 'recom_engine_archive_description'), 999);
         add_action('woocommerce_before_shop_loop', array($this, 'recom_engine_before_shop_loop'), 999);
         add_action('woocommerce_after_shop_loop', array($this, 'recom_engine_after_shop_loop'), 999);
 
-        // Category Page
-        add_action('woocommerce_after_subcategory', array($this, 'recom_engine_after_subcategory'), 999);
+        // Product Pages
+        add_action('woocommerce_before_single_product', array($this, 'recom_engine_before_single_product'), 999);
+        add_action('woocommerce_after_single_product', array($this, 'recom_engine_after_single_product'), 999);
 
         // Checkout Page
         add_action('woocommerce_before_checkout_form', array($this, 'recom_engine_before_checkout_form'), 999);
         add_action('woocommerce_after_checkout_form', array($this, 'recom_engine_after_checkout_form'), 999);
         add_action('woocommerce_before_checkout_registration_form', array($this, 'recom_engine_before_checkout_registration_form'), 999);
         add_action('woocommerce_after_checkout_registration_form', array($this, 'recom_engine_after_checkout_registration_form'), 999);
+
+        // Thank You Page
+        add_action('woocommerce_thankyou', array($this, 'recom_engine_thank_you_page'), 999);
 
         // Hooks used for JavaScript functions
         add_action('woocommerce_before_main_content', array($this, 'send_category'), 30, 0);
@@ -141,34 +144,30 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                 'description' => 'Allows the display of customized products carousel on your website pages',
                 'type' => 'title',
             ),
-            'recom_engine_home_page' => array(
-                'title' => __('Home Page'),
-                'label' => __('Display on Home Page'),
+            'recom_engine_home_category_page' => array(
+                'title' => __('Home & Category Pages'),
                 'description' => __('Enables the display of Recommendation Engine Carousel on your Home page'),
                 'type' => 'select',
                 'options' => array(
                     'none' => 'None',
-                    'before_main_content' => 'Display before Main Content',
-                    'after_main_content' => 'Display after Main Content',
-                    'archive_description' => 'Display in Archive Description',
-                    'before_shop_loop' => 'Display before Shop Loop',
-                    'after_shop_loop' => 'Display after Shop Loop'
+                    'archive_description' => 'Display in Archive Description (above Products Box Listing',
+                    'before_shop_loop' => 'Display before Shop Loop (before Products Box Listing)',
+                    'after_shop_loop' => 'Display after Shop Loop (after Products Box Listing)'
                 ),
+                'default' => 'before_shop_loop',
             ),
-            'recom_engine_category_page' => array(
-                'title' => __('Category Page'),
-                'label' => __('Display Recommendation Engine on Category page'),
-                'description' => __('Enables the display of Recommendation Engine Carousel on your Category page'),
+            'recom_engine_product_page' => array(
+                'title' => __('Product Pages'),
+                'description' => __('Enables the display of Recommendation Engine Carousel on Checkout page'),
                 'type' => 'select',
                 'options' => array(
                     'none' => 'None',
-                    'after_subcategory' => 'Display after Subcategory', 
-                    'test2' => 'sal2'
+                    'before_single_product' => 'Display before Single Product',
+                    'after_single_product' => 'Display after Single Product'
                 ),
             ),
             'recom_engine_checkout_form' => array(
-                'title' => __('Checkout Page'),
-                'label' => __('Display Recommendation Engine on Checkout page'),
+                'title' => __('Checkout Pages'),
                 'description' => __('Enables the display of Recommendation Engine Carousel on Checkout page'),
                 'type' => 'select',
                 'options' => array(
@@ -178,6 +177,12 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                     'before_checkout_registration_form' => 'Display before Checkout Registration Form',
                     'after_checkout_registration_form' => 'Display after Checkout Registration Form'
                 ),
+            ),
+            'recom_engine_thank_you_page' => array(
+                'title' => __('Thank You Page'),
+                'description' => __('Enables the display of Recommendation Engine Carousel on Thank You page'),
+                'type' => 'checkbox',
+                'default' => 'yes'
             ),
         );
     }
@@ -214,31 +219,11 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     }
 
     /*
-    * Recommendation Engine for Before Main Content - Home Page
-    */
-    public function recom_engine_before_main_content()
-    {
-        if ( $this->recom_engine_home_page == 'before_main_content' ) {
-            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
-        }
-    }
-
-    /*
-    * Recommendation Engine for Before Main Content - Home Page
-    */
-    public function recom_engine_after_main_content()
-    {
-        if ( $this->recom_engine_home_page == 'after_main_content' ) {
-            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
-        }
-    }
-
-    /*
     * Recommendation Engine for After Shop Loop - Home Page
     */
     public function recom_engine_after_shop_loop()
     {
-        if ( $this->recom_engine_home_page == 'after_shop_loop' ) {
+        if ( $this->recom_engine_home_category_page == 'after_shop_loop' ) {
             echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }
@@ -248,7 +233,7 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     */
     public function recom_engine_before_shop_loop()
     {
-        if ( $this->recom_engine_home_page == 'before_shop_loop' ) {
+        if ( $this->recom_engine_home_category_page == 'before_shop_loop' ) {
             echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }
@@ -258,18 +243,28 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     */
     public function recom_engine_archive_description()
     {
-        if ( $this->recom_engine_home_page == 'archive_description' ) {
+        if ( $this->recom_engine_home_category_page == 'archive_description' ) {
             echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }
 
     /*
-    * Recommendation Engine for After Subcategory
+    * Recommendation Engine for Before Single Product
     */
-    public function recom_engine_after_subcategory()
+    public function recom_engine_before_single_product()
     {
-        if ( $this->recom_engine_after_subcategory == 'after_subcategory' ) {
-            echo '<div id="retargeting-recommeng-category-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ( $this->recom_engine_product_page == 'before_single_product' ) {
+            echo '<div id="retargeting-recommeng-product-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for Afer Single Product
+    */
+    public function recom_engine_after_single_product()
+    {
+        if ( $this->recom_engine_product_page == 'after_single_product' ) {
+            echo '<div id="retargeting-recommeng-product-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }
 
@@ -296,7 +291,8 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     /*
     * Recommendation Engine for After Checkout Registration Form
     */
-    public function recom_engine_before_checkout_registration_form() {
+    public function recom_engine_before_checkout_registration_form()
+    {
         if ( $this->recom_engine_checkout_form == 'before_checkout_registration_form' ) {
             echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
@@ -305,9 +301,20 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     /*
     * Recommendation Engine for After Checkout Registration Form
     */
-    public function recom_engine_after_checkout_registration_form() {
+    public function recom_engine_after_checkout_registration_form()
+    {
         if ( $this->recom_engine_checkout_form == 'after_checkout_registration_form' ) {
             echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        }
+    }
+
+    /*
+    * Recommendation Engine for Thank You Page
+    */
+    public function recom_engine_thank_you_page()
+    {
+        if ( $this->recom_engine_thank_you_page == 'yes') {
+            echo '<div id="retargeting-recommeng-thank-you-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
         }
     }
 
@@ -596,7 +603,7 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
 
             foreach ((array)$order->get_items() as $item_id => $item) {
                 $_product = apply_filters('woocommerce_order_item_product', $order->get_product_from_item($item), $item);
-                $item_meta = new WC_Order_Item_Meta($item['item_meta'], $_product);
+                $item_meta = new WC_Order_Item_Product($item['item_meta'], $_product);
                 if (apply_filters('woocommerce_order_item_visible', true, $item)) {
                     $line_item = array(
                         'id' => $item['product_id'],

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -582,8 +582,8 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                         "name": "' . htmlspecialchars($product->get_title()) . '",
                         "url": "' . get_permalink() . '",
                         "img": "' . $image_url . '",
-                        "price": ' . $price . ',
-                        "promo": ' . $specialPrice . ',
+                        "price": "' . $price . '",
+                        "promo": "' . $specialPrice . '",
                         "inventory": {
                             "variations": false,
                             "stock": ' . $stock . ',

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -7,7 +7,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-require_once(dirname(__FILE__) . '/../lib/Retargeting_REST_API_Client.php');
+require_once dirname(__FILE__) . '/../lib/Retargeting_REST_API_Client.php';
 
 class WC_Integration_Retargeting_Tracking extends WC_Integration
 {
@@ -17,30 +17,30 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         'grouped'
     );
 
-    /*
-    * Construct
-    */
+    /**
+     * Constructor method.
+     */
     public function __construct()
     {
-        $this->id                 = 'retargeting';
-        $this->method_title       = "Retargeting Tracker";
+        $this->id = 'retargeting';
+        $this->method_title = 'Retargeting Tracker';
         $this->method_description = __('Retargeting.Biz is a marketing automation tool that boosts the conversion rate and sales of your online store.');
 
         $this->init_form_fields();
         $this->init_settings();
 
-        $this->domain_api_key                  = esc_attr( $this->get_option('domain_api_key') );
-        $this->token                           = esc_attr( $this->get_option('token') );
-        $this->add_to_cart_button_id           = esc_attr( $this->get_option('add_to_cart_button_id') );
-        $this->price_label_id                  = esc_attr( $this->get_option('price_label_id') );
-        $this->help_pages                      = $this->get_option('help_pages');
-        $this->recom_engine_home_page          = esc_attr( $this->get_option('recom_engine_home_page') );
-        $this->recom_engine_category_page      = esc_attr( $this->get_option('recom_engine_category_page') );
-        $this->recom_engine_product_page       = esc_attr( $this->get_option('recom_engine_product_page') );
-        $this->recom_engine_cart_page          = esc_attr( $this->get_option('recom_engine_cart_page'));
-        $this->recom_engine_checkout_form      = esc_attr( $this->get_option('recom_engine_checkout_form') );
-        $this->recom_engine_thank_you_page     = esc_attr( $this->get_option('recom_engine_thank_you_page') );
-        
+        $this->domain_api_key = esc_attr($this->get_option('domain_api_key'));
+        $this->token = esc_attr($this->get_option('token'));
+        $this->add_to_cart_button_id = esc_attr($this->get_option('add_to_cart_button_id'));
+        $this->price_label_id = esc_attr($this->get_option('price_label_id'));
+        $this->help_pages = $this->get_option('help_pages');
+        $this->recom_engine_home_page = esc_attr($this->get_option('recom_engine_home_page'));
+        $this->recom_engine_category_page = esc_attr($this->get_option('recom_engine_category_page'));
+        $this->recom_engine_product_page = esc_attr($this->get_option('recom_engine_product_page'));
+        $this->recom_engine_cart_page = esc_attr($this->get_option('recom_engine_cart_page'));
+        $this->recom_engine_checkout_form = esc_attr($this->get_option('recom_engine_checkout_form'));
+        $this->recom_engine_thank_you_page = esc_attr($this->get_option('recom_engine_thank_you_page'));
+
         add_action('init', array($this, 'ra_session_init'), 1);
 
         add_action('woocommerce_update_options_integration_retargeting', array($this, 'process_admin_options'));
@@ -87,9 +87,9 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         add_action('woocommerce_before_single_product', array($this, 'send_product'), 20, 0);
 
         add_action('woocommerce_after_add_to_cart_button', array($this, 'add_to_cart'));
-        
-        add_action( 'woocommerce_after_cart', array($this, 'remove_from_cart' ));
-        add_action( 'woocommerce_after_mini_cart', array($this, 'remove_from_cart' ));
+
+        add_action('woocommerce_after_cart', array($this, 'remove_from_cart'));
+        add_action('woocommerce_after_mini_cart', array($this, 'remove_from_cart'));
 
         add_action('woocommerce_before_single_product', array($this, 'click_image'), 30, 0);
 
@@ -102,19 +102,20 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
 
         add_action('template_redirect', array($this, 'discount_api_template'));
         add_filter('query_vars', array($this, 'retargeting_api_add_query_vars'));
-
     }
 
-    /*
-    * Init admin form
-    */
-    function init_form_fields()
+    /**
+     * Init admin form
+     *
+     * @return void
+     */
+    public function init_form_fields()
     {
         // List all pages
         $allPages = get_pages();
         $pages = array();
         foreach ($allPages as $key => $page) {
-            $pages['ra_none']        = 'None';
+            $pages['ra_none'] = 'None';
             $pages[$page->post_name] = $page->post_title;
         }
 
@@ -221,24 +222,27 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
             ),
         );
     }
-    
-    /*
-    *   Initialize WP session
-    */
-    function ra_session_init() 
+
+    /**
+     * Initialize WP session
+     *
+     * @return void
+     */
+    public function ra_session_init()
     {
-        if ( !session_id() ) {
+        if (!session_id()) {
             session_start();
         }
-        
     }
-    
-    /*
-    * Retargeting Tracking Code
-    */
+
+    /**
+     * Retargeting Tracking Code
+     *
+     * @return void
+     */
     public function get_retargeting_tracking_code()
     {
-        echo '<!-- Retargeting Tracking Code '. WC_Retargeting_Tracking::VERSION .'-->
+        echo '<!-- Retargeting Tracking Code ' . WC_Retargeting_Tracking::VERSION . '-->
        <script type="text/javascript">
         (function(){
         ra_key = "' . esc_js($this->domain_api_key) . '";
@@ -253,154 +257,183 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         <!-- Retargeting Tracking Code -->';
     }
 
-    /*
-    * Recommendation Engine for Archive Description - Home Page
-    */
+    /**
+     * Recommendation Engine for Archive Description - Home Page
+     *
+     * @return void
+     */
     public function recom_engine_archive_description_home_page()
     {
-        if ( $this->recom_engine_home_page == 'archive_description' && !is_product_category() ) {
-            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>'; 
+        if ($this->recom_engine_home_page == 'archive_description' && !is_product_category()) {
+            echo '<div id="retargeting-recommeng-home-page"></div>';
         }
     }
 
-    /*
-    * Recommendation Engine for Before Shop Loop - Home Page
-    */
+    /**
+     * Recommendation Engine for Before Shop Loop - Home Page
+     *
+     * @return void
+     */
     public function recom_engine_before_shop_loop_home_page()
     {
-        if ( $this->recom_engine_home_page == 'category_before_shop_loop' && !is_product_category() ) {
-            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ($this->recom_engine_home_page == 'category_before_shop_loop' && !is_product_category()) {
+            echo '<div id="retargeting-recommeng-home-page"></div>';
         }
     }
 
-    /*
-    * Recommendation Engine for After Shop Loop - Home Page
-    */
+    /**
+     * Recommendation Engine for After Shop Loop - Home Page
+     *
+     * @return void
+     */
     public function recom_engine_after_shop_loop_home_page()
     {
-        if ( $this->recom_engine_home_page == 'category_after_shop_loop' && !is_product_category() ) {
-            echo '<div id="retargeting-recommeng-home-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ($this->recom_engine_home_page == 'category_after_shop_loop' && !is_product_category()) {
+            echo '<div id="retargeting-recommeng-home-page"></div>';
         }
     }
 
-    /*
-    * Recommendation Engine for After Shop Loop - Category Page
-    */
+    /**
+     * Recommendation Engine for After Shop Loop - Category Page
+     *
+     * @return void
+     */
     public function recom_engine_after_shop_loop_category_page()
     {
-        if ( $this->recom_engine_category_page == 'after_shop_loop' && is_product_category() ) {
-            echo '<div id="retargeting-recommeng-category-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ($this->recom_engine_category_page == 'after_shop_loop' && is_product_category()) {
+            echo '<div id="retargeting-recommeng-category-page"></div>';
         }
     }
 
-    /*
-    * Recommendation Engine for Before Shop Loop - Category Page
-    */
+    /**
+     * Recommendation Engine for Before Shop Loop - Category Page
+     *
+     * @return void
+     */
     public function recom_engine_before_shop_loop_category_page()
     {
-        if ( $this->recom_engine_category_page == 'before_shop_loop' && is_product_category() ) {
-            echo '<div id="retargeting-recommeng-category-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ($this->recom_engine_category_page == 'before_shop_loop' && is_product_category()) {
+            echo '<div id="retargeting-recommeng-category-page"></div>';
         }
     }
 
-    /*
-    * Recommendation Engine for Archive Description - Category Page
-    */
+    /**
+     * Recommendation Engine for Archive Description - Category Page
+     *
+     * @return void
+     */
     public function recom_engine_archive_description_category_page()
     {
-        if ( $this->recom_engine_category_page == 'archive_description' && is_product_category() ) {
-            echo '<div id="retargeting-recommeng-category-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ($this->recom_engine_category_page == 'archive_description' && is_product_category()) {
+            echo '<div id="retargeting-recommeng-category-page"></div>';
         }
     }
 
-    /*
-    * Recommendation Engine for Before Single Product
-    */
-
+    /**
+     * Recommendation Engine for Before Single Product
+     *
+     * @return void
+     */
     public function recom_engine_before_single_product()
     {
-        if ( $this->recom_engine_product_page == 'before_single_product' ) {
-            echo '<div id="retargeting-recommeng-product-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ($this->recom_engine_product_page == 'before_single_product') {
+            echo '<div id="retargeting-recommeng-product-page"></div>';
         }
     }
 
-    /*
-    * Recommendation Engine for Afer Single Product
-    */
+    /**
+     * Recommendation Engine for Afer Single Product
+     *
+     * @return void
+     */
     public function recom_engine_after_single_product_summary()
     {
-        if ( $this->recom_engine_product_page == 'after_single_product_summary' ) {
-            echo '<div id="retargeting-recommeng-product-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ($this->recom_engine_product_page == 'after_single_product_summary') {
+            echo '<div id="retargeting-recommeng-product-page"></div>';
         }
     }
 
-    /*
-    * Recommendation Engine for before Cart Table - Cart Page
-    */
+    /**
+     * Recommendation Engine for before Cart Table - Cart Page
+     *
+     * @return void
+     */
     public function recom_engine_before_cart_table()
     {
-        if ( $this->recom_engine_cart_page == 'before_cart_table' ) {
-            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ($this->recom_engine_cart_page == 'before_cart_table') {
+            echo '<div id="retargeting-recommeng-checkout-page"></div>';
         }
     }
 
-    /*
-    * Recommendation Engine for before Cart Contents - Cart Page
-    */
+    /**
+     * Recommendation Engine for before Cart Contents - Cart Page
+     *
+     * @return void
+     */
     public function recom_engine_cart_contents()
     {
-        if ( $this->recom_engine_cart_page == 'after_cart_contents' ) {
-            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ($this->recom_engine_cart_page == 'after_cart_contents') {
+            echo '<div id="retargeting-recommeng-checkout-page"></div>';
         }
     }
 
-    /*
-    * Recommendation Engine for Before Checkout Form
-    */
+    /**
+     * Recommendation Engine for Before Checkout Form
+     *
+     * @return void
+     */
     public function recom_engine_before_checkout_form()
     {
-        if ( $this->recom_engine_checkout_form == 'before_checkout_form' ) {
-            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ($this->recom_engine_checkout_form == 'before_checkout_form') {
+            echo '<div id="retargeting-recommeng-checkout-page"></div>';
         }
     }
 
-    /*
-    * Recommendation Engine for After Checkout Form
-    */
+    /**
+     * Recommendation Engine for After Checkout Form
+     *
+     * @return void
+     */
     public function recom_engine_after_checkout_form()
     {
-        if ( $this->recom_engine_checkout_form == 'after_checkout_form' ) {
-            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ($this->recom_engine_checkout_form == 'after_checkout_form') {
+            echo '<div id="retargeting-recommeng-checkout-page"></div>';
         }
     }
 
-    /*
-    * Recommendation Engine for After Checkout Registration Form
-    */
+    /**
+     * Recommendation Engine for After Checkout Registration Form
+     *
+     * @return void
+     */
     public function recom_engine_before_checkout_registration_form()
     {
-        if ( $this->recom_engine_checkout_form == 'before_checkout_registration_form' ) {
-            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ($this->recom_engine_checkout_form == 'before_checkout_registration_form') {
+            echo '<div id="retargeting-recommeng-checkout-page"></div>';
         }
     }
 
-    /*
-    * Recommendation Engine for After Checkout Registration Form
-    */
+    /**
+     * Recommendation Engine for After Checkout Registration Form
+     *
+     * @return void
+     */
     public function recom_engine_after_checkout_registration_form()
     {
-        if ( $this->recom_engine_checkout_form == 'after_checkout_registration_form' ) {
-            echo '<div id="retargeting-recommeng-checkout-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ($this->recom_engine_checkout_form == 'after_checkout_registration_form') {
+            echo '<div id="retargeting-recommeng-checkout-page"></div>';
         }
     }
 
-    /*
-    * Recommendation Engine for Thank You Page
-    */
+    /**
+     * Recommendation Engine for Thank You Page
+     *
+     * @return void
+     */
     public function recom_engine_thank_you_page()
     {
-        if ( $this->recom_engine_thank_you_page == 'yes') {
-            echo '<div id="retargeting-recommeng-thank-you-page"><img src="https://nastyhobbit.org/data/media/3/happy-panda.jpg"></div>';
+        if ($this->recom_engine_thank_you_page == 'yes') {
+            echo '<div id="retargeting-recommeng-thank-you-page"></div>';
         }
     }
 
@@ -410,7 +443,7 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     // public function recom_engine_search_page( $content )
     // {
     //     global $wp_query;
-        
+
     //     if ( isset($wp_query->query) && is_search() ) {
     //         return $content . '<p>RETARGETING - I\'m filtering the content inside the main loop</p>';
     //     }
@@ -418,9 +451,11 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     //     return $content;
     // }
 
-    /*
-    * setEmail
-    */
+    /**
+     * setEmail
+     *
+     * @return void
+     */
     public function set_email()
     {
         global $woocommerce;
@@ -443,9 +478,11 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         }
     }
 
-    /*
-    * sendCategory
-    */
+    /**
+     * sendCategory
+     *
+     * @return void
+     */
     public function send_category()
     {
         if (is_product_category()) {
@@ -485,9 +522,11 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         }
     }
 
-    /*
+    /**
      * sendProduct
-     * */
+     *
+     * @return void
+     */
     public function send_product()
     {
         if (is_product()) {
@@ -496,8 +535,6 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
             $variation_id = get_post_meta($this->id, '_min_regular_price_variation_id', true);
 
             if ($product instanceof WC_Product && $product->is_type(self::$product_type)) {
-
-
                 // Prices
 
                 // Simple product type
@@ -510,8 +547,8 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                         list($price, $specialPrice) = $this->getPricesForGroupedProducts($product);
                         break;
                     default:
-                        $price = wc_get_price_including_tax( $product, array('price' => $product->get_regular_price() ) );
-                        $salePrice = wc_get_price_including_tax( $product, array('price' => $product->get_price() ) );
+                        $price = wc_get_price_including_tax($product, array('price' => $product->get_regular_price()));
+                        $salePrice = wc_get_price_including_tax($product, array('price' => $product->get_price()));
                         $salePrice = $price == $salePrice ? 0 : $salePrice;
                         $specialPrice = (!empty($salePrice) ? $salePrice : 0);
                         break;
@@ -532,8 +569,8 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                     }
                 } else {
                     $cat['catid'] = 1;
-                    $cat['cat'] = "Root";
-                    $cat['catparent'] = "false";
+                    $cat['cat'] = 'Root';
+                    $cat['catparent'] = 'false';
                 }
 
                 $stock = $product->is_in_stock() ? 1 : 0;
@@ -598,14 +635,15 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
           })(jQuery);
 
                     </script>';
-
             }
         }
     }
 
-    /*
-    * addToCart
-    */
+    /**
+     * addToCart
+     *
+     * @return void
+     */
     public function add_to_cart()
     {
         if (is_product()) {
@@ -620,10 +658,12 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                 </script>';
         }
     }
-    
-    /*
-    * removeFromCart
-    */
+
+    /**
+     * removeFromCart
+     *
+     * @return void
+     */
     public function remove_from_cart()
     {
         echo '<script>
@@ -638,10 +678,12 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                   })(jQuery);
             </script>';
     }
-    
-    /*
-    * clickImage
-    */
+
+    /**
+     * clickImage
+     *
+     * @return void
+     */
     public function click_image()
     {
         global $product;
@@ -662,9 +704,12 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         ';
     }
 
-    /*
-    * saveOrder
-    */
+    /**
+     * saveOrder
+     *
+     * @param [string] $order_id
+     * @return void
+     */
     public function save_order($order_id)
     {
         if (is_numeric($order_id) && $order_id > 0) {
@@ -695,12 +740,11 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                         'name' => $item['name'],
                         'price' => $item['line_subtotal'],
                         'quantity' => $item['qty'],
-                        'variation_code' => ($item['variation_id'] == 0) ? "" : $item['variation_id']
+                        'variation_code' => ($item['variation_id'] == 0) ? '' : $item['variation_id']
                     );
                 }
                 $data['line_items'][] = $line_item;
             }
-            
 
             echo '<script>
                 var _ra = _ra || {};
@@ -712,7 +756,7 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
                     "phone": "' . $order->get_billing_phone() . '",
                     "state": "' . $order->get_billing_state() . '",
                     "city": "' . $order->get_billing_city() . '",
-                    "address": "' . $order->get_billing_address_1() . " " . $order->get_billing_address_2() . '",
+                    "address": "' . $order->get_billing_address_1() . ' ' . $order->get_billing_address_2() . '",
                     "discount_code": "' . $coupons_list . '",
                     "discount": ' . (empty($order->get_discount) ? 0 : $order->get_discount) . ',
                     "shipping": ' . (empty($order->get_total_shipping) ? 0 : $order->get_total_shipping) . ',
@@ -733,34 +777,33 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         //REST API
 
         $orderInfo = array(
-            "order_no" => $order->get_id(),
-            "lastname" => $order->get_billing_last_name(),
-            "firstname" => $order->get_billing_first_name(),
-            "email" => $order->get_billing_email(),
-            "phone" => $order->get_billing_phone(),
-            "state" => $order->get_billing_state(),
-            "city" => $order->get_billing_city(),
-            "address" => $order->get_billing_address_1() . " " . $order->get_billing_address_2(),
-            "discount_code" => $coupons_list,
-            "discount" => (empty($order->get_discount) ? 0 : $order->get_discount),
-            "shipping" => (empty($order->get_total_shipping) ? 0 : $order->get_total_shipping),
-            "total" => $order->get_total()
+            'order_no' => $order->get_id(),
+            'lastname' => $order->get_billing_last_name(),
+            'firstname' => $order->get_billing_first_name(),
+            'email' => $order->get_billing_email(),
+            'phone' => $order->get_billing_phone(),
+            'state' => $order->get_billing_state(),
+            'city' => $order->get_billing_city(),
+            'address' => $order->get_billing_address_1() . ' ' . $order->get_billing_address_2(),
+            'discount_code' => $coupons_list,
+            'discount' => (empty($order->get_discount) ? 0 : $order->get_discount),
+            'shipping' => (empty($order->get_total_shipping) ? 0 : $order->get_total_shipping),
+            'total' => $order->get_total()
         );
 
         if ($this->token && $this->token != '') {
-
             $orderClient = new Retargeting_REST_API_Client($this->token);
-            $orderClient->setResponseFormat("json");
+            $orderClient->setResponseFormat('json');
             $orderClient->setDecoding(false);
             $response = $orderClient->order->save($orderInfo, $data['line_items']);
-
         }
-
     }
 
-    /*
-    * visitHelpPage
-    */
+    /**
+     * visitHelpPage
+     *
+     * @return void
+     */
     public function help_pages()
     {
         global $post;
@@ -783,9 +826,11 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         }
     }
 
-    /*
-    * checkoutIds
-    */
+    /**
+     * checkoutIds
+     *
+     * @return void
+     */
     public function checkout_ids()
     {
         global $woocommerce;
@@ -809,42 +854,52 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         }
     }
 
-    /*
-     * URL DISCOUNT API
+    /**
+     * URL DISCOUNT API.
+     *
+     * @param [array] $vars
+     * @return void
      */
-    function retargeting_api_add_query_vars($vars)
+    public function retargeting_api_add_query_vars($vars)
     {
-        $vars[] = "retargeting";
-        $vars[] = "key";
-        $vars[] = "value";
-        $vars[] = "type";
-        $vars[] = "count";
+        $vars[] = 'retargeting';
+        $vars[] = 'key';
+        $vars[] = 'value';
+        $vars[] = 'type';
+        $vars[] = 'count';
         return $vars;
     }
 
-    function discount_api_template($template)
+    /**
+     * URL Discount Template.
+     *
+     * @param [mixed] $template
+     * @return void
+     */
+    public function discount_api_template($template)
     {
         global $wp_query;
 
         if (isset($wp_query->query['retargeting']) && $wp_query->query['retargeting'] == 'discounts') {
             if (isset($wp_query->query['key']) && isset($wp_query->query['value']) && isset($wp_query->query['type']) && isset($wp_query->query['count'])) {
-                if ($wp_query->query['key'] != "" && $wp_query->query['key'] == $this->token && $wp_query->query['value'] != "" && $wp_query->query['type'] != "" && $wp_query->query['count'] != "") {
+                if ($wp_query->query['key'] != '' && $wp_query->query['key'] == $this->token && $wp_query->query['value'] != '' && $wp_query->query['type'] != '' && $wp_query->query['count'] != '') {
                     // If everything is ok, generate and show the discount codes
                     echo generate_coupons($wp_query->query['count']);
                     exit;
                 } else {
-                    echo json_encode(array("status" => false, "error" => "0002: Invalid Parameters!"));
+                    echo json_encode(array('status' => false, 'error' => '0002: Invalid Parameters!'));
                     exit;
                 }
             } else {
-                echo json_encode(array("status" => false, "error" => "0001: Missing Parameters!"));
+                echo json_encode(array('status' => false, 'error' => '0001: Missing Parameters!'));
                 exit;
             }
         }
     }
 
     /**
-     * @param $product
+     * Processes prices for variable products.
+     * @param [object] $product
      * @return array
      */
     private function getPricesForVariableProducts($product)
@@ -854,8 +909,8 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         $max_price = end($prices['regular_price']);
         $price = $min_price !== $max_price ? $max_price : $min_price;
         $specialPrice = $min_price !== $max_price ? $min_price : 0;
-        $price = wc_get_price_including_tax( $product, array('price' => $price) );
-        $specialPrice = wc_get_price_including_tax( $product, array('price' => $specialPrice) );
+        $price = wc_get_price_including_tax($product, array('price' => $price));
+        $specialPrice = wc_get_price_including_tax($product, array('price' => $specialPrice));
         return array(
             (!empty($price) ? $price : 0),
             (!empty($specialPrice) ? $specialPrice : 0)
@@ -863,7 +918,8 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     }
 
     /**
-     * @param $product
+     * Processes prices for grouped products.
+     * @param [object] $product
      * @return array
      */
     private function getPricesForGroupedProducts($product)
@@ -872,8 +928,8 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
         $price = (!empty($getPrice) ? $getPrice : 0);
         $getSpecialPrice = $product->get_sale_price();
         $specialPrice = (!empty($getSpecialPrice) ? $getSpecialPrice : 0);
-        $price = wc_get_price_including_tax( $product, array('price' => $price) );
-        $specialPrice = wc_get_price_including_tax( $product, array('price' => $specialPrice) );
+        $price = wc_get_price_including_tax($product, array('price' => $price));
+        $specialPrice = wc_get_price_including_tax($product, array('price' => $specialPrice));
         return array(
             (!empty($price) ? $price : 0),
             (!empty($specialPrice) ? $specialPrice : 0)
@@ -881,34 +937,39 @@ class WC_Integration_Retargeting_Tracking extends WC_Integration
     }
 }
 
-// Generate random discount codes
-
+/**
+ * Generate random discount codes.
+ *
+ * @param [integer] $count
+ * @return void
+ */
 function generate_coupons($count)
 {
     global $wp_query;
 
-    $couponChars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    $couponChars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
     $couponCodes = array();
     for ($x = 0; $x < $count; $x++) {
-        $couponCode = "";
+        $couponCode = '';
         for ($i = 0; $i < 8; $i++) {
-
             $couponCode .= $couponChars[mt_rand(0, strlen($couponChars) - 1)];
-
         }
         if (woocommerce_verify_discount($couponCode)) {
-
             woocommerce_add_discount($couponCode, $wp_query->query['value'], $wp_query->query['type']);
             $couponCodes[] = $couponCode;
-
         } else {
             $x -= 1;
         }
-
     }
     return json_encode($couponCodes);
 }
 
+/**
+ * Verifies the discount code.
+ *
+ * @param [string] $code
+ * @return void
+ */
 function woocommerce_verify_discount($code)
 {
     global $woocommerce;
@@ -916,14 +977,18 @@ function woocommerce_verify_discount($code)
     if ($o->exists == 1) {
         return false;
     } else {
-
         return true;
     }
-
 }
 
-// Add discount codes into WooCommerce
-
+/**
+ * Add discount codes into WooCommerce
+ *
+ * @param [string] $code
+ * @param [string] $discount
+ * @param [string] $type
+ * @return void
+ */
 function woocommerce_add_discount($code, $discount, $type)
 {
     global $wp_query;
@@ -968,6 +1033,4 @@ function woocommerce_add_discount($code, $discount, $type)
     update_post_meta($new_coupon_id, 'expiry_date', '');
     update_post_meta($new_coupon_id, 'apply_before_tax', 'yes');
     update_post_meta($new_coupon_id, 'free_shipping', 'no');
-
-
 }

--- a/classes/class-wc-retargeting-tracking.php
+++ b/classes/class-wc-retargeting-tracking.php
@@ -1033,7 +1033,7 @@ function woocommerce_add_discount($code, $discount, $type)
     // Add meta
     update_post_meta($new_coupon_id, 'discount_type', $discount_type);
     update_post_meta($new_coupon_id, 'coupon_amount', $amount);
-    update_post_meta($new_coupon_id, 'individual_use', 'no');
+    update_post_meta($new_coupon_id, 'individual_use', 'yes');
     update_post_meta($new_coupon_id, 'product_ids', '');
     update_post_meta($new_coupon_id, 'exclude_product_ids', '');
     update_post_meta($new_coupon_id, 'usage_limit', '');

--- a/js/notice-dismiss.js
+++ b/js/notice-dismiss.js
@@ -1,0 +1,11 @@
+jQuery(document).ready(function() {
+	jQuery("#retargeting-dismiss-notice").on('click', function() {
+		sessionStorage.setItem('hidden', 'true');
+	});
+
+	var retSession = sessionStorage.getItem('hidden');
+	if ( retSession  ) {
+		jQuery("#retargeting-dismiss-notice").hide();
+	}
+});
+

--- a/js/notice-dismiss.js
+++ b/js/notice-dismiss.js
@@ -1,9 +1,9 @@
 jQuery(document).ready(function() {
 	jQuery("#retargeting-dismiss-notice").on('click', function() {
-		sessionStorage.setItem('hidden', 'true');
+		sessionStorage.setItem('_ra_hidden', 'true');
 	});
 
-	var retSession = sessionStorage.getItem('hidden');
+	var retSession = sessionStorage.getItem('_ra_hidden');
 	if ( retSession  ) {
 		jQuery("#retargeting-dismiss-notice").hide();
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: retargeting
 Tags: retargeting, WooCommerce
 Requires at least: 4.6
-Tested up to: 4.9.1
-Stable tag: 4.9.1
+Tested up to: 4.9.4
+Stable tag: 4.9.4
 Requires WooCommerce at least: 3.0.0
-Tested WooCommerce up to: 3.2.6
+Tested WooCommerce up to: 3.3.1
 License: GPLv2
 
 Retargeting is a marketing automation tool that boosts the conversion rate and sales of your online store.

--- a/woocommerce-retargeting-plugin.php
+++ b/woocommerce-retargeting-plugin.php
@@ -19,7 +19,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 **/
 
 if(!class_exists('WC_Retargeting_Tracking') ) :
+
 session_start();
+
 class WC_Retargeting_Tracking {
     /*
     * Plugin Version.

--- a/woocommerce-retargeting-plugin.php
+++ b/woocommerce-retargeting-plugin.php
@@ -10,85 +10,108 @@
  */
 
 // Exit if accessed directly
-if ( ! defined( 'ABSPATH' ) ) { 
-    exit; 
+if (!defined('ABSPATH')) {
+    exit;
 }
 
 /**
 * Check if WooCommerce is active
 **/
 
-if(!class_exists('WC_Retargeting_Tracking') ) :
+if (!class_exists('WC_Retargeting_Tracking')) :
 
 session_start();
 
-class WC_Retargeting_Tracking {
+class WC_Retargeting_Tracking
+{
     /*
     * Plugin Version.
+    * @var string
     */
     const VERSION = '3.0.0';
+
     /*
     * Instance of this class
+    * @var null
     */
     protected static $instance = null;
-    /*
-    * Init plugin
-    */
-    private function __construct() {
-      	add_action( 'init', array($this, 'load_plugin_textdomain') );
-        add_action('admin_enqueue_scripts', array($this, 'notice_dismiss'));
-      	// Check if WooCommerce is installed.
-      	if(class_exists('WC_Integration') && defined('WOOCOMMERCE_VERSION') && version_compare(WOOCOMMERCE_VERSION, '3.0.0', '>=') ) {
-      	    include_once 'classes/class-wc-retargeting-tracking.php';
-      	    
-      	    // Register integration
-      	    add_filter('woocommerce_integrations', array($this, 'add_integration'));
-      	} else {
-      	    add_action('admin_notices', array($this, 'woocommerce_missing_notice'));
-      	}
-    }
-    
-    /*
-    * Return an instance of this class
-    */
-    public static function get_instance() 
+
+    /**
+     * Init plugin.
+     */
+    private function __construct()
     {
-      	if(null == self::$instance) {
-      	    self::$instance = new self;
-      	}
-      	return self::$instance;
+        add_action('init', array($this, 'load_plugin_textdomain'));
+        add_action('admin_enqueue_scripts', array($this, 'notice_dismiss'));
+        // Check if WooCommerce is installed.
+        if (class_exists('WC_Integration') && defined('WOOCOMMERCE_VERSION') && version_compare(WOOCOMMERCE_VERSION, '3.0.0', '>=')) {
+            include_once 'classes/class-wc-retargeting-tracking.php';
+
+            // Register integration
+            add_filter('woocommerce_integrations', array($this, 'add_integration'));
+        } else {
+            add_action('admin_notices', array($this, 'woocommerce_missing_notice'));
+        }
     }
-    /*
-    * Load the plugin text domain for translation
-    */
+
+    /**
+     * Return an instance of this class.
+     *
+     * @return void
+     */
+    public static function get_instance()
+    {
+        if (null == self::$instance) {
+            self::$instance = new self;
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Load the plugin text domain for translation.
+     *
+     * @return void
+     */
     public function load_plugin_textdomain()
     {
-      	$locale = apply_filters('plugin_locale', get_locale(), 'woocommerce-retargeting-integration');
-      	load_textdomain('woocommerce-retargeting-integration', trailingslashit(WP_LANG_DIR) . 'woocommerce-retargeting-integration-' . $locale . '.mo');
-      	load_plugin_textdomain ('woocommerce-retargeting-integration', false, dirname(plugin_basename( __FILE__ )) . '/languages/');
-    }
-    /*
-    * Fallback notice in case WooCommerce 3.0 is NOT installed
-    */
-    public function woocommerce_missing_notice() 
-    {
-          echo '<div id="retargeting-dismiss-notice" class="notice notice-error retargeting-dismiss-notice is-dismissible"><p>' . sprintf(__('<b>WooCommerce Retargeting</b> depends on the last version of %s to work! If you are <b>NOT</b> using <b>WooCommerce 3.0+</b> please e-mail us at info@retargeting.biz and we will help you set up the installation.', 'woocommerce-retargeting-integration'), '<a href=' . esc_url('http://www.woothemes.com/woocommerce/') . ' ' . 'target="_blank" rel="noopener noreferrer">' . __('WooCommerce', 'woocommerce-retargeting-integration') . '</a>').'</p></div>';
+        $locale = apply_filters('plugin_locale', get_locale(), 'woocommerce-retargeting-integration');
+        load_textdomain('woocommerce-retargeting-integration', trailingslashit(WP_LANG_DIR) . 'woocommerce-retargeting-integration-' . $locale . '.mo');
+        load_plugin_textdomain('woocommerce-retargeting-integration', false, dirname(plugin_basename(__FILE__)) . '/languages/');
     }
 
-    function notice_dismiss()
+    /**
+     * Fallback notice in case WooCommerce 3.0 is NOT installed.
+     *
+     * @return void
+     */
+    public function woocommerce_missing_notice()
     {
-        wp_enqueue_script( 'my_custom_script', plugin_dir_url(__FILE__) . 'js/notice-dismiss.js', array('jquery'), '1.0');
+        echo '<div id="retargeting-dismiss-notice" class="notice notice-error retargeting-dismiss-notice is-dismissible"><p>' . sprintf(__('<b>WooCommerce Retargeting</b> depends on the last version of %s to work! If you are <b>NOT</b> using <b>WooCommerce 3.0+</b> please e-mail us at info@retargeting.biz and we will help you set up the installation.', 'woocommerce-retargeting-integration'), '<a href=' . esc_url('http://www.woothemes.com/woocommerce/') . ' ' . 'target="_blank" rel="noopener noreferrer">' . __('WooCommerce', 'woocommerce-retargeting-integration') . '</a>') . '</p></div>';
     }
 
-    /*
-    * Add new integration to WooCommerce
-    */
-    public function add_integration($integrations) {
-      	$integrations[] = 'WC_Integration_Retargeting_Tracking';
-      	return $integrations;
+    /**
+     * Injects 'notice-dismiss.js' file into plugin's admin page.
+     *
+     * @return void
+     */
+    public function notice_dismiss()
+    {
+        wp_enqueue_script('my_custom_script', plugin_dir_url(__FILE__) . 'js/notice-dismiss.js', array('jquery'), '1.0');
+    }
+
+    /**
+     * Add new integration to WooCommerce.
+     *
+     * @param [array] $integrations
+     * @return void
+     */
+    public function add_integration($integrations)
+    {
+        $integrations[] = 'WC_Integration_Retargeting_Tracking';
+        return $integrations;
     }
 }
-add_action('plugins_loaded', array('WC_Retargeting_Tracking', 'get_instance'), 0 );
+
+add_action('plugins_loaded', array('WC_Retargeting_Tracking', 'get_instance'), 0);
 
 endif;
-

--- a/woocommerce-retargeting-plugin.php
+++ b/woocommerce-retargeting-plugin.php
@@ -78,7 +78,7 @@ class WC_Retargeting_Tracking {
       	return $integrations;
     }
 }
-add_action('plugins_loaded', array('WC_Retargeting_Tracking', 'get_instance'),0);
+add_action('plugins_loaded', array('WC_Retargeting_Tracking', 'get_instance'), 0 );
 
 endif;
 

--- a/woocommerce-retargeting-plugin.php
+++ b/woocommerce-retargeting-plugin.php
@@ -68,7 +68,7 @@ class WC_Retargeting_Tracking {
     * Fallback notice in case WooCommerce 3.0 is NOT installed
     */
     public function woocommerce_missing_notice(){
-	       echo '<div class="error"><p>'.sprintf(__('<b>WooCommerce Retargeting</b> depends on the last version of %s to work! If you are <b>NOT</b> using <b>WooCommerce 3.0+</b> please e-mail us at info@retargeting.biz and we will help you set up the installation.', 'woocommerce-retargeting-integration'), '<a href="http://www.woothemes.com/woocommerce/" target="_blank" rel="noopener noreferrer">' . __('WooCommerce', 'woocommerce-retargeting-integration') . '</a>').'</p></div>';
+	       echo '<div class="error"><p>'.sprintf(__('<b>WooCommerce Retargeting</b> depends on the last version of %s to work! If you are <b>NOT</b> using <b>WooCommerce 3.0+</b> please e-mail us at info@retargeting.biz and we will help you set up the installation.', 'woocommerce-retargeting-integration'), '<a href=' . esc_url('http://www.woothemes.com/woocommerce/') . ' ' . 'target="_blank" rel="noopener noreferrer">' . __('WooCommerce', 'woocommerce-retargeting-integration') . '</a>').'</p></div>';
     }
     /*
     * Add new integration to WooCommerce

--- a/woocommerce-retargeting-plugin.php
+++ b/woocommerce-retargeting-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Retargeting
  * Plugin URI: https://retargeting.biz/woocommerce-documentation
  * Description: Retargeting is a marketing automation tool that boosts the conversion rate and sales of your online store.
- * Version: 2.0.20
+ * Version: 3.0.0
  * Author: Retargeting Team
  * Author URI: http://retargeting.biz
  * License: GPL2
@@ -26,7 +26,7 @@ class WC_Retargeting_Tracking {
     /*
     * Plugin Version.
     */
-    const VERSION = '2.0.20';
+    const VERSION = '3.0.0';
     /*
     * Instance of this class
     */

--- a/woocommerce-retargeting-plugin.php
+++ b/woocommerce-retargeting-plugin.php
@@ -34,7 +34,7 @@ class WC_Retargeting_Tracking {
     /*
     * Init plugin
     */
-    private function __construct(){
+    private function __construct() {
       	add_action( 'init', array($this, 'load_plugin_textdomain') );
         add_action('admin_enqueue_scripts', array($this, 'notice_dismiss'));
       	// Check if WooCommerce is installed.
@@ -61,7 +61,7 @@ class WC_Retargeting_Tracking {
     /*
     * Load the plugin text domain for translation
     */
-    public function load_plugin_textdomain() 
+    public function load_plugin_textdomain()
     {
       	$locale = apply_filters('plugin_locale', get_locale(), 'woocommerce-retargeting-integration');
       	load_textdomain('woocommerce-retargeting-integration', trailingslashit(WP_LANG_DIR) . 'woocommerce-retargeting-integration-' . $locale . '.mo');
@@ -72,7 +72,7 @@ class WC_Retargeting_Tracking {
     */
     public function woocommerce_missing_notice() 
     {
-          echo '<div id="retargeting-dismiss-notice" class="notice notice-error retargeting-dismiss-notice is-dismissible"><p>'.sprintf(__('<b>WooCommerce Retargeting</b> depends on the last version of %s to work! If you are <b>NOT</b> using <b>WooCommerce 3.0+</b> please e-mail us at info@retargeting.biz and we will help you set up the installation.', 'woocommerce-retargeting-integration'), '<a href=' . esc_url('http://www.woothemes.com/woocommerce/') . ' ' . 'target="_blank" rel="noopener noreferrer">' . __('WooCommerce', 'woocommerce-retargeting-integration') . '</a>').'</p></div>';
+          echo '<div id="retargeting-dismiss-notice" class="notice notice-error retargeting-dismiss-notice is-dismissible"><p>' . sprintf(__('<b>WooCommerce Retargeting</b> depends on the last version of %s to work! If you are <b>NOT</b> using <b>WooCommerce 3.0+</b> please e-mail us at info@retargeting.biz and we will help you set up the installation.', 'woocommerce-retargeting-integration'), '<a href=' . esc_url('http://www.woothemes.com/woocommerce/') . ' ' . 'target="_blank" rel="noopener noreferrer">' . __('WooCommerce', 'woocommerce-retargeting-integration') . '</a>').'</p></div>';
     }
 
     function notice_dismiss()

--- a/woocommerce-retargeting-plugin.php
+++ b/woocommerce-retargeting-plugin.php
@@ -35,7 +35,8 @@ class WC_Retargeting_Tracking {
     * Init plugin
     */
     private function __construct(){
-      	add_action('init', array($this, 'load_plugin_textdomain') );
+      	add_action( 'init', array($this, 'load_plugin_textdomain') );
+        add_action('admin_enqueue_scripts', array($this, 'notice_dismiss'));
       	// Check if WooCommerce is installed.
       	if(class_exists('WC_Integration') && defined('WOOCOMMERCE_VERSION') && version_compare(WOOCOMMERCE_VERSION, '3.0.0', '>=') ) {
       	    include_once 'classes/class-wc-retargeting-tracking.php';
@@ -50,7 +51,8 @@ class WC_Retargeting_Tracking {
     /*
     * Return an instance of this class
     */
-    public static function get_instance(){
+    public static function get_instance() 
+    {
       	if(null == self::$instance) {
       	    self::$instance = new self;
       	}
@@ -59,7 +61,8 @@ class WC_Retargeting_Tracking {
     /*
     * Load the plugin text domain for translation
     */
-    public function load_plugin_textdomain(){
+    public function load_plugin_textdomain() 
+    {
       	$locale = apply_filters('plugin_locale', get_locale(), 'woocommerce-retargeting-integration');
       	load_textdomain('woocommerce-retargeting-integration', trailingslashit(WP_LANG_DIR) . 'woocommerce-retargeting-integration-' . $locale . '.mo');
       	load_plugin_textdomain ('woocommerce-retargeting-integration', false, dirname(plugin_basename( __FILE__ )) . '/languages/');
@@ -67,9 +70,16 @@ class WC_Retargeting_Tracking {
     /*
     * Fallback notice in case WooCommerce 3.0 is NOT installed
     */
-    public function woocommerce_missing_notice(){
-	       echo '<div class="error"><p>'.sprintf(__('<b>WooCommerce Retargeting</b> depends on the last version of %s to work! If you are <b>NOT</b> using <b>WooCommerce 3.0+</b> please e-mail us at info@retargeting.biz and we will help you set up the installation.', 'woocommerce-retargeting-integration'), '<a href=' . esc_url('http://www.woothemes.com/woocommerce/') . ' ' . 'target="_blank" rel="noopener noreferrer">' . __('WooCommerce', 'woocommerce-retargeting-integration') . '</a>').'</p></div>';
+    public function woocommerce_missing_notice() 
+    {
+          echo '<div id="retargeting-dismiss-notice" class="notice notice-error retargeting-dismiss-notice is-dismissible"><p>'.sprintf(__('<b>WooCommerce Retargeting</b> depends on the last version of %s to work! If you are <b>NOT</b> using <b>WooCommerce 3.0+</b> please e-mail us at info@retargeting.biz and we will help you set up the installation.', 'woocommerce-retargeting-integration'), '<a href=' . esc_url('http://www.woothemes.com/woocommerce/') . ' ' . 'target="_blank" rel="noopener noreferrer">' . __('WooCommerce', 'woocommerce-retargeting-integration') . '</a>').'</p></div>';
     }
+
+    function notice_dismiss()
+    {
+        wp_enqueue_script( 'my_custom_script', plugin_dir_url(__FILE__) . 'js/notice-dismiss.js', array('jquery'), '1.0');
+    }
+
     /*
     * Add new integration to WooCommerce
     */


### PR DESCRIPTION
Changes:

- Add Recommendation Engine (Webshop Personalization) feature. The user should select from Retargeting Tracker plugin's admin settings the desired areas of the website to insert the carousel. Areas options come by default.
- Add escaping functions to enhance security.
- Changed coding style to PSR-2
- Add documentation for each method
- Changed `WC_Order_Item_Meta` to `WC_Order_Item_Product`
- Fixed a bug where `help_pages()` was returning an `undefined` if the `$post` was not found
- The message that tells you to install WooCommerce 3.0+ can now be closed and stored into a session
- Individual code use only set to `yes`
- Rewrite a new documentation into `README.md` file

To do:

- [ ] Implement Recommendation Engine for Search page which takes into account the word from the search query